### PR TITLE
Use css modules

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -10,4 +10,36 @@ module.exports = {
 		'@storybook/addon-docs',
 		'@storybook/preset-scss',
 	],
+	webpackFinal(config) {
+		const rules = config.module.rules.filter(rule => !isScssRule(rule));
+		const scssRule = {
+			test: /\.scss$/,
+			oneOf: [{
+				resourceQuery: /module/,
+				use: [{
+					loader: 'style-loader',
+				}, {
+					loader: 'css-loader',
+					options: { modules: { localIdentName: '[name]_[local]_[hash:base64:5]' }},
+				}, {
+					loader: 'sass-loader',
+				}],
+			}, {
+				use: [
+					'style-loader',
+					'css-loader',
+					'sass-loader',
+				],
+			}],
+		};
+
+		rules.push(scssRule);
+		config.module.rules = rules; // eslint-disable-line no-param-reassign
+
+		return config;
+	},
 };
+
+function isScssRule(rule) {
+	return rule.test && rule.test instanceof RegExp && rule.test.test('.scss');
+}

--- a/components/accordion.vue
+++ b/components/accordion.vue
@@ -1,10 +1,10 @@
 <template>
-	<div :class="['accordion', { 'accordion--open': isOpen }]">
-		<div class="accordion__title-wrapper" @click="toggle">
+	<div :class="[$style.root, { [$style.isOpen]: isOpen }]">
+		<div :class="$style.title" @click="toggle">
 			<div>{{ title }}</div>
-			<arrow-down-icon class="accordion__icon" />
+			<arrow-down-icon :class="$style.icon" />
 		</div>
-		<div v-if="isOpen" class="accordion__slot">
+		<div v-if="isOpen" :class="$style.slot">
 			<slot />
 		</div>
 	</div>
@@ -35,18 +35,18 @@ export default {
 };
 </script>
 
-<style scoped lang="scss">
+<style module lang="scss">
 	@import '../styles/variables';
 
 	$accordion-padding: $spacing-06;
 
-	.accordion {
+	.root {
 		border: 1px solid $border-color;
 		border-radius: $border-radius;
 		margin-bottom: $spacing-06;
 	}
 
-	.accordion__title-wrapper {
+	.title {
 		padding: $accordion-padding;
 		display: flex;
 		align-items: center;
@@ -54,19 +54,19 @@ export default {
 		cursor: pointer;
 	}
 
-	.accordion__icon {
+	.icon {
 		flex-shrink: 0;
 		width: $spacing-05;
 		fill: $border-color;
 		margin-left: $spacing-06;
 	}
 
-	.accordion__slot {
+	.slot {
 		padding: 0 $accordion-padding $accordion-padding;
 	}
 
-	.accordion--open {
-		.accordion__icon {
+	.isOpen {
+		.icon {
 			transform: rotate(180deg);
 		}
 	}

--- a/components/address-radio-button-card.vue
+++ b/components/address-radio-button-card.vue
@@ -1,13 +1,13 @@
 <template>
 	<radio-button-card :value="address" v-model="model">
 		<template>
-			<div v-if="title" class="address-radio-button-card__title">{{ title }}</div>
+			<div v-if="title" :class="$style.title">{{ title }}</div>
 
 			<div>{{ address.streetAddress }}</div>
 			<div v-if="address.extendedAddress">{{ address.extendedAddress }}</div>
 			<div>{{ address.locality }}, {{ address.region }} {{ address.postal }}</div>
 
-			<div v-if="address.phone" class="address-radio-button-card__details">{{ phone }}</div>
+			<div v-if="address.phone" :class="$style.details">{{ phone }}</div>
 		</template>
 	</radio-button-card>
 </template>
@@ -48,16 +48,16 @@ export default {
 };
 </script>
 
-<style scoped lang="scss">
+<style module lang="scss">
 	@import '../styles/variables';
 	@import '../styles/mixins';
 
-	.address-radio-button-card__title {
+	.title {
 		margin-bottom: $spacing-04;
 		@include text-bold();
 	}
 
-	.address-radio-button-card__details {
+	.details {
 		margin-top: $spacing-04;
 		@include text-body-small();
 	}

--- a/components/breadcrumbs.vue
+++ b/components/breadcrumbs.vue
@@ -1,8 +1,8 @@
 <template>
-	<div class="breadcrumbs">
+	<div>
 		<span v-for="(breadcrumb, index) in breadcrumbs" :key="index">
-			<span class="breadcrumbs__breadcrumb" @click="$emit('select', breadcrumb)">{{ breadcrumb.name }}</span>
-			<span v-if="index < breadcrumbs.length - 1" class="breadcrumbs__divider"> / </span>
+			<span :class="$style.breadcrumb" @click="$emit('select', breadcrumb)">{{ breadcrumb.name }}</span>
+			<span v-if="index < breadcrumbs.length - 1" :class="$style.divider"> / </span>
 		</span>
 	</div>
 </template>
@@ -18,10 +18,10 @@ export default {
 };
 </script>
 
-<style scoped lang="scss">
+<style module lang="scss">
 	@import '../styles/mixins';
 
-	.breadcrumbs__breadcrumb {
+	.breadcrumb {
 		@include text-subtle();
 		cursor: pointer;
 
@@ -31,7 +31,7 @@ export default {
 		}
 	}
 
-	.breadcrumbs__divider {
+	.divider {
 		@include text-subtle();
 	}
 </style>

--- a/components/card.vue
+++ b/components/card.vue
@@ -1,13 +1,13 @@
 <template>
-	<div class="card">
+	<div :class="$style.root">
 		<slot />
 	</div>
 </template>
 
-<style scoped lang="scss">
+<style module lang="scss">
 @import '../styles/variables';
 
-.card {
+.root {
 	padding: $spacing-04;
 	border-radius: $border-radius;
 	background-color: $beige;

--- a/components/cart-item-card.vue
+++ b/components/cart-item-card.vue
@@ -1,17 +1,17 @@
 <template>
-	<card class="cart-item-card">
-		<div class="cart-item-card__image-wrapper">
-			<img class="cart-item-card__image" :src="item.imageSrc" :alt="item.name" />
+	<card :class="$style.root">
+		<div :class="$style.imageWrapper">
+			<img :class="$style.image" :src="item.imageSrc" :alt="item.name" />
 		</div>
 
-		<div class="cart-item-card__description-wrapper">
-			<div class="cart-item-card__description">
-				<div class="cart-item-card__title">{{ item.name }}</div>
-				<div class="cart-item-card__additional-info">{{ additionalInformation }}</div>
-				<div class="cart-item-card__quantity">Qty {{ item.quantity }}</div>
+		<div :class="$style.descriptionWrapper">
+			<div :class="$style.description">
+				<div :class="$style.title">{{ item.name }}</div>
+				<div :class="$style.additionalInfo">{{ additionalInformation }}</div>
+				<div :class="$style.quantity">Qty {{ item.quantity }}</div>
 			</div>
 
-			<span class="cart-item-card__price">{{ displayPrice }}</span>
+			<span :class="$style.price">{{ displayPrice }}</span>
 		</div>
 	</card>
 </template>
@@ -41,45 +41,45 @@ export default {
 };
 </script>
 
-<style scoped lang="scss">
+<style module lang="scss">
 	@import '../styles/mixins';
 	@import '../styles/variables';
 
-	.cart-item-card {
+	.root {
 		display: flex;
 		padding: $spacing-04;
 		margin-bottom: $spacing-03;
 	}
 
-	.cart-item-card__image-wrapper {
+	.imageWrapper {
 		width: $spacing-10;
 		margin-right: $spacing-04;
 	}
 
-	.cart-item-card__image {
+	.image {
 		width: 100%;
 	}
 
-	.cart-item-card__description-wrapper {
+	.descriptionWrapper {
 		display: flex;
 		flex: 1;
 	}
 
-	.cart-item-card__description {
+	.description {
 		flex: 1;
 	}
 
-	.cart-item-card__title,
-	.cart-item-card__price {
+	.title,
+	.price {
 		@include text-bold();
 	}
 
-	.cart-item-card__additional-info,
-	.cart-item-card__quantity {
+	.additionalInfo,
+	.quantity {
 		@include text-body-small();
 	}
 
-	.cart-item-card__additional-info {
+	.additionalInfo {
 		color: $color-text-gray;
 		margin-bottom: $spacing-03;
 	}

--- a/components/cart-summary.vue
+++ b/components/cart-summary.vue
@@ -1,37 +1,37 @@
 <template>
-	<div class="cart-summary">
-		<div class="cart-summary__header cart-summary__row">
-			<div class="cart-summary__title">Your Cart</div>
-			<div class="cart-summary__item-count">{{ cart.itemCount }} Items</div>
+	<div>
+		<div :class="[$style.header, $style.row]">
+			<div :class="$style.title">Your Cart</div>
+			<div :class="$style.itemCount">{{ cart.itemCount }} Items</div>
 		</div>
 
 		<cart-item-card v-for="(item, index) in cart.items" :key="index" :item="item" />
 
-		<div class="cart-summary__prices-summary">
-			<div class="cart-summary__prices-summary-row cart-summary__row">
+		<div :class="$style.pricesSummary">
+			<div :class="[$style.pricesSummaryRow, $style.row]">
 				<div>Subtotal</div>
 				<div>{{ formatCurrency(cart.subtotal) }}</div>
 			</div>
 
-			<div class="cart-summary__prices-summary-row cart-summary__row">
+			<div :class="[$style.pricesSummaryRow, $style.row]">
 				<div>Shipping/Delivery</div>
 				<div v-if="cart.shippingPrice">{{ formatCurrency(cart.shippingPrice) }}</div>
-				<div v-else class="cart-summary__shipping-info">calculated at next step</div>
+				<div v-else :class="$style.shippingInfo">calculated at next step</div>
 			</div>
 
 			<div v-if="cart.discounts && cart.discounts.length">
-				<div class="cart-summary__prices-summary-row cart-summary__row"
+				<div :class="[$style.pricesSummaryRow, $style.row]"
 				     v-for="discount in cart.discounts"
 				     :key="discount.name">
-					<div class="cart-summary__discount-label">{{ discount.name }}</div>
-					<div class="cart-summary__discount-amount">{{ formatCurrency(-Math.abs(discount.amount)) }}</div>
+					<div :class="$style.discountLabel">{{ discount.name }}</div>
+					<div :class="$style.discountAmount">{{ formatCurrency(-Math.abs(discount.amount)) }}</div>
 				</div>
 			</div>
 		</div>
 
-		<div class="cart-summary__row">
-			<div class="cart-summary__total-label">Estimated Total</div>
-			<div class="cart-summary__total">{{ formatCurrency(cart.total) }}</div>
+		<div :class="$style.row">
+			<div :class="$style.totalLabel">Estimated Total</div>
+			<div :class="$style.total">{{ formatCurrency(cart.total) }}</div>
 		</div>
 	</div>
 </template>
@@ -56,29 +56,29 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style module lang="scss">
 	@import '../styles/mixins';
 	@import '../styles/variables';
 
-	.cart-summary__row {
+	.row {
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
 	}
 
-	.cart-summary__header {
+	.header {
 		margin-bottom: $spacing-07;
 	}
 
-	.cart-summary__title {
+	.title {
 		@include text-heading-4();
 	}
 
-	.cart-summary__item-count {
+	.itemCount {
 		@include text-bold();
 	}
 
-	.cart-summary__prices-summary {
+	.pricesSummary {
 		border-width: 1px 0;
 		border-style: solid;
 		border-color: $border-color-light;
@@ -86,21 +86,21 @@ export default {
 		margin: $spacing-06 0;
 	}
 
-	.cart-summary__prices-summary-row {
+	.pricesSummaryRow {
 		line-height: $spacing-06;
 	}
 
-	.cart-summary__shipping-info {
+	.shippingInfo {
 		@include text-body-small();
 	}
 
-	.cart-summary__discount-label,
-	.cart-summary__discount-amount,
-	.cart-summary__total-label {
+	.discountLabel,
+	.discountAmount,
+	.totalLabel {
 		@include text-bolder();
 	}
 
-	.cart-summary__total {
+	.total {
 		@include text-heading-5();
 	}
 </style>

--- a/components/content-wrapper.vue
+++ b/components/content-wrapper.vue
@@ -1,15 +1,15 @@
 <template>
-	<div class="content-wrapper">
-		<div class="content-wrapper__content">
+	<div>
+		<div :class="$style.content">
 			<slot />
 		</div>
 	</div>
 </template>
 
-<style scoped lang="scss">
+<style module lang="scss">
 @import '../styles/variables';
 
-.content-wrapper__content {
+.content {
 	max-width: $max-width-laptop-large;
 	margin: 0 auto;
 	padding: 0 $spacing-04;

--- a/components/feature-highlight-row.vue
+++ b/components/feature-highlight-row.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="feature-highlight-row">
+	<div :class="$style.root">
 		<feature-highlight
 			v-for="(feature, index) in features"
 			:key="index"
@@ -21,10 +21,10 @@ export default {
 };
 </script>
 
-<style scoped lang="scss">
+<style module lang="scss">
 	@import '../styles/variables';
 
-	.feature-highlight-row {
+	.root {
 		display: grid;
 		grid-template-columns: repeat(3, 1fr);
 		grid-gap: $spacing-10;

--- a/components/feature-highlight.vue
+++ b/components/feature-highlight.vue
@@ -1,7 +1,7 @@
 <template>
-	<div class="feature-highlight">
+	<div>
 		<img :src="icon" />
-		<div class="feature-highlight__title">{{ title }}</div>
+		<div :class="$style.title">{{ title }}</div>
 		<div v-html="description" />
 	</div>
 </template>
@@ -16,11 +16,11 @@ export default {
 };
 </script>
 
-<style scoped lang="scss">
+<style module lang="scss">
 @import '../styles/variables';
 @import '../styles/mixins';
 
-.feature-highlight__title {
+.title {
 	@include text-heading-5;
 	margin: $spacing-05 0 $spacing-02;
 }

--- a/components/image-banner.vue
+++ b/components/image-banner.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="image-background" :style="cssVariables">
+	<div :class="$style.root" :style="cssVariables">
 		<span role="img" :aria-label="alt"></span>
 		<div><slot /></div>
 	</div>
@@ -23,10 +23,10 @@ export default {
 };
 </script>
 
-<style scoped lang="scss">
+<style module lang="scss">
 	@import '../styles/variables';
 
-	.image-background {
+	.root {
 		height: 100vh;
 		width: 100%;
 		display: flex;
@@ -39,7 +39,7 @@ export default {
 	}
 
 	@media (max-width: $max-width-tablet) {
-		.image-background {
+		.root {
 			background-image: var(--mobileImage);
 		}
 	}

--- a/components/media-row.vue
+++ b/components/media-row.vue
@@ -1,13 +1,13 @@
 <template>
-	<div class="media-row">
-		<div class="media-row__content-wrapper">
+	<div :class="$style.root">
+		<div :class="$style.contentWrapper">
 			<div>
-				<img v-if="icon" class="media-row__icon" :src="icon" />
-				<div class="media-row__title">{{ title }}</div>
-				<div class="media-row__text" v-html="description" />
+				<img v-if="icon" :class="$style.icon" :src="icon" />
+				<div :class="$style.title">{{ title }}</div>
+				<div :class="$style.text" v-html="description" />
 			</div>
 		</div>
-		<img class="media-row__image" :src="img" :alt="alt" />
+		<img :class="$style.image" :src="img" :alt="alt" />
 	</div>
 </template>
 
@@ -35,32 +35,32 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style module lang="scss">
 @import '../styles/variables';
 @import '../styles/mixins';
 
-.media-row {
+.root {
 	display: grid;
 	grid-template-columns: 1fr 1fr;
 	grid-gap: $spacing-10;
 	padding: $spacing-09;
 }
 
-.media-row__content-wrapper {
+.contentWrapper {
 	display: flex;
 	align-items: center;
 }
 
-.media-row__icon {
+.icon {
 	margin-bottom: $spacing-07;
 }
 
-.media-row__title {
+.title {
 	@include text-heading-4;
 	margin-bottom: $spacing-03;
 }
 
-.media-row__image {
+.image {
 	width: 100%;
 }
 

--- a/components/payment-method-radio-button-card.vue
+++ b/components/payment-method-radio-button-card.vue
@@ -1,9 +1,9 @@
 <template>
 	<radio-button-card :value="paymentMethod" v-model="model">
 		<template>
-			<div class="payment-method-radio-button-card__title-row">
-				<payment-method-icon class="payment-method-radio-button-card__icon" :type="paymentMethod.cardType" />
-				<span class="payment-method-radio-button-card__title">{{ paymentMethod.maskedNumber }}</span>
+			<div :class="$style.titleRow">
+				<payment-method-icon :class="$style.icon" :type="paymentMethod.cardType" />
+				<span :class="$style.title">{{ paymentMethod.maskedNumber }}</span>
 			</div>
 
 			<div>{{ paymentMethod.expirationDate }}</div>
@@ -43,22 +43,22 @@ export default {
 };
 </script>
 
-<style scoped lang="scss">
+<style module lang="scss">
 @import '../styles/variables';
 @import '../styles/mixins';
 
-.payment-method-radio-button-card__title-row {
+.titleRow {
 	display: flex;
 	align-items: center;
 	margin-bottom: $spacing-03;
 	@include text-bold();
 }
 
-.payment-method-radio-button-card__icon {
+.icon {
 	line-height: .7;
 }
 
-.payment-method-radio-button-card__title {
+.title {
 	margin-left: $spacing-03;
 }
 </style>

--- a/components/product-card-grid.vue
+++ b/components/product-card-grid.vue
@@ -1,6 +1,6 @@
 <template>
-	<div class="product-card-grid">
-		<product-card class="product-card-grid__card"
+	<div :class="$style.root">
+		<product-card
 			v-for="(card, i) in cards"
 			:product="card.product"
 			:theme="card.theme"
@@ -20,10 +20,10 @@ export default {
 };
 </script>
 
-<style scoped lang="scss">
+<style module lang="scss">
 	@import '../styles/variables';
 
-	.product-card-grid {
+	.root {
 		display: grid;
 		grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
 		grid-gap: $spacing-07;

--- a/components/product-card.vue
+++ b/components/product-card.vue
@@ -1,16 +1,16 @@
 <template>
-	<div class="product-card">
-		<a :href="product.url" class="product-card__link-wrapper">
-			<card class="product-card__card">
-				<img class="product-card__image" :src="product.imageUrl"/>
-				<div class="product-card__content">
-					<div class="product-card__title" :style="{'color' : theme.color}">{{ product.name }}</div>
-					<div class="product-card__description">{{ product.shortDescription }}</div>
+	<div :class="$style.root">
+		<a :href="product.url" :class="$style.linkWrapper">
+			<card :class="$style.card">
+				<img :class="$style.image" :src="product.imageUrl"/>
+				<div :class="$style.content">
+					<div :class="$style.title" :style="{'color' : theme.color}">{{ product.name }}</div>
+					<div :class="$style.description">{{ product.shortDescription }}</div>
 				</div>
-				<div class="product-card__bundle-items">{{ bundleItems }}</div>
+				<div :class="$style.bundleItems">{{ bundleItems }}</div>
 			</card>
 		</a>
-		<div class="product-card__footer" :style="{'backgroundColor' : theme.color}">
+		<div :class="$style.footer" :style="{'backgroundColor' : theme.color}">
 			<span>{{ product.price }}</span>
 			<button class="button--link" @click="$emit('cta-click')">Add To Cart</button>
 		</div>
@@ -60,53 +60,53 @@ export default {
 };
 </script>
 
-<style scoped lang="scss">
+<style module lang="scss">
 @import '../styles/variables';
 @import '../styles/mixins';
 
 $gutter: $spacing-07;
 
-.product-card,
-.product-card__link-wrapper {
+.root,
+.linkWrapper {
 	display: flex;
 	flex-direction: column;
 }
 
-.product-card__link-wrapper,
-.product-card__card {
+.linkWrapper,
+.card {
 	flex: 1 0 auto;
 }
 
-.product-card__card {
+.card {
 	border-bottom-right-radius: 0;
 	border-bottom-left-radius: 0;
 	padding: 0 $gutter;
 }
 
-.product-card__image {
+.image {
 	width: 100%;
 	margin: $spacing-09 0 $spacing-08;
 }
 
-.product-card__title {
+.title {
 	@include text-heading-5;
 	margin-bottom: $spacing-03;
 }
 
-.product-card__description {
+.description {
 	@include line-clamp(3);
 	height: 66px; // 3 * line-height
 	margin-bottom: $spacing-06;
 }
 
-.product-card__bundle-items {
+.bundleItems {
 	@include line-clamp(2);
 	border-top: 2px solid $beige-dark;
 	padding-top: $spacing-04;
 	margin-bottom: $spacing-06;
 }
 
-.product-card__footer {
+.footer {
 	@include text-cta;
 	display: flex;
 	justify-content: space-between;

--- a/components/radio-button-card.vue
+++ b/components/radio-button-card.vue
@@ -1,12 +1,10 @@
 <template>
-	<label class="radio-button-card">
+	<label :class="$style.root">
 		<card>
-			<span class="radio-button-card__content">
-				<span class="radio-button-card__primary-content"><slot /></span>
-				<span v-if="$slots.secondary"
-					  class="radio-button-card__secondary-content"
-				><slot name="secondary" /></span>
-				<radio-button class="radio-button-card__radio-button" :value="value" v-model="model" />
+			<span :class="$style.content">
+				<span :class="$style.primaryContent"><slot /></span>
+				<span v-if="$slots.secondary" :class="$style.secondaryContent"><slot name="secondary" /></span>
+				<radio-button :class="$style.radioButton" :value="value" v-model="model" />
 			</span>
 		</card>
 	</label>
@@ -42,31 +40,31 @@ export default {
 };
 </script>
 
-<style scoped lang="scss">
+<style module lang="scss">
 @import '../styles/variables';
 
-.radio-button-card {
+.root {
 	display: block;
 	margin-bottom: $spacing-06;
 	cursor: pointer;
 }
 
-.radio-button-card__content {
+.content {
 	display: flex;
 	position: relative;
 }
 
-.radio-button-card__primary-content {
+.primaryContent {
 	flex: 1;
 	margin-right: $spacing-06;
 	word-break: break-word;
 }
 
-.radio-button-card__secondary-content {
+.secondaryContent {
 	margin-bottom: $spacing-08;
 }
 
-.radio-button-card__radio-button {
+.radioButton {
 	position: absolute;
 	top: 50%;
 	transform: translateY(-50%);

--- a/components/radio-button.vue
+++ b/components/radio-button.vue
@@ -1,7 +1,7 @@
 <template>
-	<span class="radio-button" @click="model = value">
-		<input :id="id" class="radio-button__input" type="radio" :value="value" v-model="model" />
-		<span class="radio-button__button" />
+	<span :class="$style.root" @click="model = value">
+		<input :id="id" :class="$style.input" type="radio" :value="value" v-model="model" />
+		<span :class="$style.button" />
 	</span>
 </template>
 
@@ -31,20 +31,20 @@ export default {
 };
 </script>
 
-<style scoped lang="scss">
+<style module lang="scss">
 @import '../styles/variables';
 
-.radio-button {
+.root {
 	font-size: 0;
 	line-height: 0;
 	vertical-align: middle;
 }
 
-.radio-button__input {
+.input {
 	display: none;
 }
 
-.radio-button__button {
+.button {
 	display: inline-block;
 	height: $spacing-05;
 	width: $spacing-05;
@@ -54,7 +54,7 @@ export default {
 	cursor: pointer;
 }
 
-.radio-button__input:checked + .radio-button__button {
+.input:checked + .button {
 	background-color: $border-color;
 }
 </style>

--- a/components/store-radio-button-card.vue
+++ b/components/store-radio-button-card.vue
@@ -1,12 +1,12 @@
 <template>
 	<radio-button-card :value="store" v-model="model">
-		<div class="store-radio-button-card__title">{{ store.name }}</div>
+		<div :class="$style.title">{{ store.name }}</div>
 
 		<div>{{ store.streetAddress }}</div>
 		<div v-if="store.extendedAddress">{{ store.extendedAddress }}</div>
 		<div>{{ store.locality }}, {{ store.region }} {{ store.postal }}</div>
 
-		<div v-if="store.storeHours" class="store-radio-button-card__details">
+		<div v-if="store.storeHours" :class="$style.details">
 			<div v-for="(hours, index) in store.storeHours" :key="index">{{ hours }}</div>
 		</div>
 	</radio-button-card>
@@ -41,16 +41,16 @@ export default {
 };
 </script>
 
-<style scoped lang="scss">
+<style module lang="scss">
 @import '../styles/variables';
 @import '../styles/mixins';
 
-.store-radio-button-card__title {
+.title {
 	margin-bottom: $spacing-04;
 	@include text-bold();
 }
 
-.store-radio-button-card__details {
+.details {
 	margin-top: $spacing-04;
 	@include text-body-small();
 }

--- a/components/validated-input.vue
+++ b/components/validated-input.vue
@@ -1,10 +1,10 @@
 <template>
-	<div class="validated-input">
-		<label v-if="label" class="validated-input__label" :for="id" >{{ label }}</label>
+	<div :class="$style.root">
+		<label v-if="label" :class="$style.label" :for="id" >{{ label }}</label>
 		<label v-if="labelHelper" :for="id">{{ labelHelper }}</label>
 		<input :id="id" v-bind="$attrs" v-model="model" @blur="validate()">
 
-		<label v-if="error" class="validated-input__error" :for="id">{{ error }}</label>
+		<label v-if="error" :class="$style.error" :for="id">{{ error }}</label>
 	</div>
 </template>
 
@@ -65,19 +65,19 @@ export default {
 };
 </script>
 
-<style scoped lang="scss">
+<style module lang="scss">
 	@import '../styles/mixins';
 	@import '../styles/variables';
 
-	.validated-input {
+	.root {
 		margin-bottom: $spacing-06;
 	}
 
-	.validated-input__label {
+	.label {
 		@include text-bolder();
 	}
 
-	.validated-input__error {
+	.error {
 		@include text-error();
 	}
 </style>

--- a/components/validated-select.vue
+++ b/components/validated-select.vue
@@ -1,13 +1,13 @@
 <template>
-	<div class="validated-select">
-		<label v-if="label" class="validated-select__label" :for="id">{{ label }}</label>
+	<div :class="$style.root">
+		<label v-if="label" :class="$style.label" :for="id">{{ label }}</label>
 		<select :id="id" v-model="model">
 			<option v-for="(option, index) in options" :key="index" :value="option.value">
 				{{ option.name }}
 			</option>
 		</select>
 
-		<label v-if="error" class="validated-select__error" :for="id">{{ error }}</label>
+		<label v-if="error" :class="$style.error" :for="id">{{ error }}</label>
 	</div>
 </template>
 
@@ -69,19 +69,19 @@ export default {
 };
 </script>
 
-<style scoped lang="scss">
+<style module lang="scss">
 	@import '../styles/mixins';
 	@import '../styles/variables';
 
-	.validated-select {
+	.root {
 		margin-bottom: $spacing-06;
 	}
 
-	.validated-select__label {
+	.label {
 		@include text-bolder();
 	}
 
-	.validated-select__error {
+	.error {
 		@include text-error();
 	}
 </style>

--- a/stories/components/sections/image-banner.js
+++ b/stories/components/sections/image-banner.js
@@ -1,4 +1,3 @@
-import '../../../styles/buttons.scss';
 import ImageBanner from '../../../components/image-banner';
 
 export default {

--- a/styles/buttons.scss
+++ b/styles/buttons.scss
@@ -47,6 +47,7 @@ input[type="submit"]:disabled {
 }
 
 .button--link {
+	color: inherit;
 	padding: 0;
 	line-height: 1;
 	height: auto;

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -3,3 +3,4 @@
 @import 'generic';
 @import 'typography';
 @import 'alerts';
+@import 'buttons';


### PR DESCRIPTION
This PR changes updates all components to use CSS modules.

**CSS modules provide two benefits.**
1. They prevent component styles from leaking out of the component-library and affecting the parent project (similar to scoped styles).
2. They prevent the styles of the parent project from affecting the component-library.

**Summary of changes**
- The "block" fragment has been removed from class names in components. So, instead of writing `.block__element` you would just write `.element`. Note that in the rendered content, the file name will be added to the class name to serve as the block fragment. So, if you have a file named `block.vue` and use the `.element` class, it will render as `.block_element_hash`.

- Class names are now camelCase for ease of dereferencing them as object properties in your Vue templates (e.g. `:class="$style.className"` instead of `:class="$style['class-name']"`).
- The rendered class is `.[name]_[local]_[hash:base64:5]` where `[name]` is the file name without the extension, `[local]` is the class name used in your file (i.e. `.element`), and `[hash:base64:5]` is a 5 character base64 hash. The `[name]` will be kebab-case since file names are kebab case. `[local]` will be camelCase since CSS class names are now camelCase. An example rendered class name is `product-card_bundleItems_40QWD`.

- We can use double underscores as separators between the file name, class name, and hash fragments. However, I chose not to at this time because I would have to modify two webpack configs in different ways (storybook and vue). But let me know if this is important to the team. I think that the single underscores will still provide a good visual separation because none of the fragments use snake_case. Usually, double underscores are used when combining two snake_case fragments.

- Since the file name is added to the class during build time, I felt that it is redundant use the component name as the class name for the root element. This would lead to rendered class names such as `.component-name_componentName_hash`. Instead, I opted to use `.root` as the naming convention for the root element. This would result in rendered classes like `.component-name_root_hash`. I also considered using `.component`. Let me know if there is a different convention you'd like to follow.

- There may be an argument for using camelCase filenames to product classes like `.fileName_localName_hash` instead of `.file-name_localName_hash`