### PR TITLE
silas/add validated payment method to index

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -26,4 +26,5 @@ export { default as StoreAddress } from './store-address';
 export { default as StoreRadioButtonCard } from './store-radio-button-card';
 export { default as ValidatedForm } from './validated-form';
 export { default as ValidatedInput } from './validated-input';
+export { default as ValidatedPaymentMethod } from './validated-payment-method';
 export { default as ValidatedSelect } from './validated-select';


### PR DESCRIPTION
The Validated Payment Method needs to be exported from the index for it to be used in the ecommerce site.