### PR TITLE
silas/add services to files block in package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"assets/**/*",
 		"components/**/*",
 		"constants/**/*",
+		"services/**/*",
 		"styles/**/*",
 		"utilities/**/*"
 	],


### PR DESCRIPTION
Services need to be added to the files list so that component libraries can access them when used in the ecommerce site.