### PR TITLE
silas/shrink payment method icons

### DIFF
--- a/components/icons/american-express-icon.vue
+++ b/components/icons/american-express-icon.vue
@@ -1,5 +1,5 @@
 <template>
-	<svg width="66px" height="46px" viewBox="0 0 66 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<svg width="44px" height="25px" viewBox="0 0 66 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 		<!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
 		<title>American Express</title>
 		<desc>Created with Sketch.</desc>

--- a/components/icons/american-express-icon.vue
+++ b/components/icons/american-express-icon.vue
@@ -1,5 +1,5 @@
 <template>
-	<svg width="44px" height="25px" viewBox="0 0 66 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<svg viewBox="0 0 66 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 		<!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
 		<title>American Express</title>
 		<desc>Created with Sketch.</desc>

--- a/components/icons/discover-icon.vue
+++ b/components/icons/discover-icon.vue
@@ -1,5 +1,5 @@
 <template>
-	<svg width="66px" height="46px" viewBox="0 0 66 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<svg width="44px" height="25px" viewBox="0 0 66 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 		<!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
 		<title>Discover</title>
 		<desc>Created with Sketch.</desc>

--- a/components/icons/discover-icon.vue
+++ b/components/icons/discover-icon.vue
@@ -1,5 +1,5 @@
 <template>
-	<svg width="44px" height="25px" viewBox="0 0 66 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<svg viewBox="0 0 66 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 		<!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
 		<title>Discover</title>
 		<desc>Created with Sketch.</desc>

--- a/components/icons/master-card-icon.vue
+++ b/components/icons/master-card-icon.vue
@@ -1,5 +1,5 @@
 <template>
-	<svg width="44px" height="25px" viewBox="0 0 66 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<svg viewBox="0 0 66 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 		<!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
 		<title>Mastercard</title>
 		<desc>Created with Sketch.</desc>

--- a/components/icons/master-card-icon.vue
+++ b/components/icons/master-card-icon.vue
@@ -1,5 +1,5 @@
 <template>
-	<svg width="66px" height="46px" viewBox="0 0 66 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<svg width="44px" height="25px" viewBox="0 0 66 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 		<!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
 		<title>Mastercard</title>
 		<desc>Created with Sketch.</desc>

--- a/components/icons/unknown-payment-method-icon.vue
+++ b/components/icons/unknown-payment-method-icon.vue
@@ -1,5 +1,5 @@
 <template>
-	<svg width="44px" height="25px" viewBox="0 0 66 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<svg viewBox="0 0 66 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 		<!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
 		<title>unknown</title>
 		<desc>Created with Sketch.</desc>

--- a/components/icons/unknown-payment-method-icon.vue
+++ b/components/icons/unknown-payment-method-icon.vue
@@ -1,5 +1,5 @@
 <template>
-	<svg width="66px" height="46px" viewBox="0 0 66 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<svg width="44px" height="25px" viewBox="0 0 66 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 		<!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
 		<title>unknown</title>
 		<desc>Created with Sketch.</desc>

--- a/components/icons/visa-icon.vue
+++ b/components/icons/visa-icon.vue
@@ -1,5 +1,5 @@
 <template>
-	<svg width="44px" height="25px" viewBox="0 0 66 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<svg viewBox="0 0 66 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 		<!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
 		<title>Visa</title>
 		<desc>Created with Sketch.</desc>

--- a/components/icons/visa-icon.vue
+++ b/components/icons/visa-icon.vue
@@ -1,5 +1,5 @@
 <template>
-	<svg width="66px" height="46px" viewBox="0 0 66 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<svg width="44px" height="25px" viewBox="0 0 66 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 		<!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
 		<title>Visa</title>
 		<desc>Created with Sketch.</desc>

--- a/components/payment-method-radio-button-card.vue
+++ b/components/payment-method-radio-button-card.vue
@@ -1,14 +1,9 @@
 <template>
 	<radio-button-card :value="paymentMethod" v-model="model">
-		<template>
-			<div :class="$style.titleRow">
-				<payment-method-icon :class="$style.icon" :type="paymentMethod.cardType" />
-				<span :class="$style.title">{{ paymentMethod.maskedNumber }}</span>
-			</div>
-
-			<div>{{ paymentMethod.expirationDate }}</div>
-			<div>{{ paymentMethod.billingAddress.postalCode }}</div>
-		</template>
+		<div :class="$style.content">
+			<payment-method-icon :class="$style.icon" :type="paymentMethod.cardType" />
+			{{ paymentMethod.identifier }}
+		</div>
 	</radio-button-card>
 </template>
 
@@ -47,18 +42,14 @@ export default {
 @import '../styles/variables';
 @import '../styles/mixins';
 
-.titleRow {
+.content {
 	display: flex;
 	align-items: center;
-	margin-bottom: $spacing-03;
-	@include text-bold();
 }
 
 .icon {
-	line-height: .7;
-}
-
-.title {
-	margin-left: $spacing-03;
+	line-height: 0;
+	width: $spacing-08;
+	margin-right: $spacing-03;
 }
 </style>

--- a/stories/components/radio-button-cards/payment-method-radio-button-card.js
+++ b/stories/components/radio-button-cards/payment-method-radio-button-card.js
@@ -5,47 +5,34 @@ export default {
 	component: PaymentMethodRadioButtonCard,
 };
 
-const paymentMethod = {
-	expirationDate: '11/22',
-	billingAddress: {
-		postalCode: '93711',
-	},
-};
-
 const mastercard = {
-	maskedNumber: '····6789',
+	identifier: '····6789',
 	cardType: 'mastercard',
-	...paymentMethod,
 };
 
 const visa = {
-	maskedNumber: '····4321',
+	identifier: '····4321',
 	cardType: 'visa',
-	...paymentMethod,
 };
 
 const visa2 = {
-	maskedNumber: '····9360',
+	identifier: '····9360',
 	cardType: 'visa',
-	...paymentMethod,
 };
 
 const discover = {
-	maskedNumber: '····1111',
+	identifier: '····1111',
 	cardType: 'discover',
-	...paymentMethod,
 };
 
 const americanExpress = {
-	maskedNumber: '····2222',
+	identifier: '····2222',
 	cardType: 'american express',
-	...paymentMethod,
 };
 
 const unknown = {
-	maskedNumber: '····3563',
+	identifier: '····3563',
 	cardType: 'unknown',
-	...paymentMethod,
 };
 
 export function Overview() {
@@ -119,7 +106,7 @@ export function RadioGroup() {
 		template: `
 			<div>
 				<payment-method-radio-button-card v-for="paymentMethod in paymentMethods"
-				                                  :key="paymentMethod.maskedNumber"
+				                                  :key="paymentMethod.identifier"
 				                                  :paymentMethod="paymentMethod"
 				                                  v-model="selectedPaymentMethod" />
 			</div>


### PR DESCRIPTION
Shrinks the payment method icons to match the Zeppelin height and width.