### PR TITLE
Specify default product image heights to prevent containers from collapsing

### DIFF
--- a/components/product-card.vue
+++ b/components/product-card.vue
@@ -1,7 +1,10 @@
 <template>
 	<card @click.native="$emit('click', product)">
 		<div :class="$style.wrapper">
-			<img :class="$style.image" :src="product.imageUrl" />
+			<div :class="$style.imageContainer">
+				<img :class="$style.image" :src="product.imageUrl" />
+			</div>
+
 			<div :class="$style.name">{{ product.name }}</div>
 
 			<div v-if="hasSamePrice" :class="$style.price">{{ formatPrice(product.nonMemberPrice) }}</div>
@@ -77,8 +80,18 @@ export default {
 		align-items: center;
 	}
 
+	.imageContainer {
+		position: relative;
+		width: 100%;
+		height: 0;
+		padding-top: 100%;
+	}
+
 	.image {
-		max-width: 100%;
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
 	}
 
 	.name,

--- a/components/product-card.vue
+++ b/components/product-card.vue
@@ -1,7 +1,7 @@
 <template>
 	<card @click.native="$emit('click', product)">
 		<div :class="$style.wrapper">
-			<div :class="$style.imageContainer">
+			<div :class="$style.imageWrapper">
 				<img :class="$style.image" :src="product.imageUrl" />
 			</div>
 
@@ -80,7 +80,7 @@ export default {
 		align-items: center;
 	}
 
-	.imageContainer {
+	.imageWrapper {
 		position: relative;
 		width: 100%;
 		height: 0;

--- a/components/product-card.vue
+++ b/components/product-card.vue
@@ -85,6 +85,7 @@ export default {
 		width: 100%;
 		height: 0;
 		padding-top: 100%;
+		overflow: hidden;
 	}
 
 	.image {

--- a/components/product-card.vue
+++ b/components/product-card.vue
@@ -80,20 +80,24 @@ export default {
 		align-items: center;
 	}
 
-	.imageWrapper {
-		position: relative;
-		width: 100%;
-		height: 0;
-		padding-top: 100%;
-		overflow: hidden;
+	@mixin predefineImageSize {
+		.imageWrapper {
+			position: relative;
+			width: 100%;
+			height: 0;
+			padding-top: 100%;
+			overflow: hidden;
+		}
+
+		.image {
+			position: absolute;
+			top: 0;
+			left: 0;
+			width: 100%;
+		}
 	}
 
-	.image {
-		position: absolute;
-		top: 0;
-		left: 0;
-		width: 100%;
-	}
+	@include predefineImageSize();
 
 	.name,
 	.price {


### PR DESCRIPTION
Clickup: [Specify default product image heights to prevent containers from collapsing](https://app.clickup.com/t/c8nnqd)