### PR TITLE
Modify product-card to require users to visit PDP instead of showing quantity selector

### DIFF
--- a/components/icons/circle-arrow-right.vue
+++ b/components/icons/circle-arrow-right.vue
@@ -1,0 +1,13 @@
+<template>
+  <svg width="40px" height="40px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <title>learn more</title>
+      <g id="learn-more" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+          <g id="Up-carrot" transform="translate(20.000000, 20.000000) rotate(-270.000000) translate(-20.000000, -20.000000) translate(-0.000000, -0.000000)" stroke="#D1D1D1">
+              <line x1="20" y1="19" x2="24" y2="15" id="Path" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" transform="translate(22.000000, 17.000000) rotate(-270.000000) translate(-22.000000, -17.000000) "></line>
+              <line x1="16" y1="15" x2="20" y2="19" id="Path" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" transform="translate(18.000000, 17.000000) rotate(-270.000000) translate(-18.000000, -17.000000) "></line>
+              <line x1="16" y1="21" x2="24" y2="21" id="Path" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" transform="translate(20.000000, 21.000000) rotate(-270.000000) translate(-20.000000, -21.000000) "></line>
+              <circle id="Oval" cx="20" cy="20" r="19.5"></circle>
+          </g>
+      </g>
+  </svg>
+</template>

--- a/components/product-card.vue
+++ b/components/product-card.vue
@@ -20,7 +20,7 @@
 				@click.native.stop
 			/>
 
-			<div :class="$style.learnMore" @click="$emit('learn-more')">Learn More</div>
+			<circle-arrow-right :class="$style.learnMore" @click="$emit('learn-more')" />
 		</div>
 	</card>
 </template>

--- a/components/product-card.vue
+++ b/components/product-card.vue
@@ -19,6 +19,8 @@
 				@change="quantity => $emit('change', { product, quantity })"
 				@click.native.stop
 			/>
+
+			<div :class="$style.learnMore" @click="$emit('learn-more')">Learn More</div>
 		</div>
 	</card>
 </template>
@@ -91,5 +93,17 @@ export default {
 
 	.strikethrough {
 		text-decoration: line-through;
+	}
+
+	.learnMore {
+		@include _button--pill;
+
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 140px;
+		height: 40px;
+		border: 1px solid $gray-30;;
+		cursor: pointer;
 	}
 </style>

--- a/components/product-card.vue
+++ b/components/product-card.vue
@@ -97,14 +97,6 @@ export default {
 	}
 
 	.learnMore {
-		@include _button--pill;
-
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		width: 140px;
-		height: 40px;
-		border: 1px solid $gray-30;;
 		cursor: pointer;
 	}
 </style>

--- a/components/product-card.vue
+++ b/components/product-card.vue
@@ -21,15 +21,14 @@
 				@change="quantity => $emit('change', { product, quantity })"
 				@click.native.stop
 			/>
-
 		</div>
 	</card>
 </template>
 
 <script>
 import Card from './card';
-import QuantitySelector from './quantity-selector';
 import CircleArrowRight from './icons/circle-arrow-right';
+import QuantitySelector from './quantity-selector';
 import { formatCurrency } from '../utilities/formatters';
 
 export default {

--- a/components/product-card.vue
+++ b/components/product-card.vue
@@ -28,10 +28,11 @@
 <script>
 import Card from './card';
 import QuantitySelector from './quantity-selector';
+import CircleArrowRight from './icons/circle-arrow-right';
 import { formatCurrency } from '../utilities/formatters';
 
 export default {
-	components: { Card, QuantitySelector },
+	components: { Card, QuantitySelector, CircleArrowRight },
 
 	props: {
 		product: {

--- a/components/product-card.vue
+++ b/components/product-card.vue
@@ -14,13 +14,14 @@
 				{{ formatPrice(product.memberSalePrice) }}
 			</div>
 
-			<quantity-selector
+			<circle-arrow-right v-if="showLearnMoreButton" :class="$style.learnMore" @click="$emit('learn-more')" />
+
+			<quantity-selector v-else
 				:quantity="quantity"
 				@change="quantity => $emit('change', { product, quantity })"
 				@click.native.stop
 			/>
 
-			<circle-arrow-right :class="$style.learnMore" @click="$emit('learn-more')" />
 		</div>
 	</card>
 </template>

--- a/components/product-card.vue
+++ b/components/product-card.vue
@@ -43,6 +43,10 @@ export default {
 			type: Number,
 			required: false,
 		},
+		showLearnMoreButton: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	computed: {


### PR DESCRIPTION
Clickup: [Modify product-card to require users to visit PDP instead of showing quantity selector](https://app.clickup.com/t/bmh7dr)

Mobile Web PR: https://github.com/Pressed-Juicery/mobile-web/pull/90