### PR TITLE
Fix: prevent grid children from displaying unevenly

### DIFF
--- a/components/validated-payment-method.vue
+++ b/components/validated-payment-method.vue
@@ -192,6 +192,7 @@ export default {
 		display: grid;
 		grid-template-columns: repeat(3, 1fr);
 		grid-gap: $spacing-05;
+		align-items: flex-end;
 	}
 
 	.label {


### PR DESCRIPTION
Clickup: [Test Pressed Cash on Website](https://app.clickup.com/t/depgvy)
Dependency of: https://github.com/Pressed-Juicery/ecomm/pull/92, https://github.com/Pressed-Juicery/ecomm/pull/93

Makes Figure 1 display like Figure 2.

**Figure 1.**
![Screen Shot 2020-10-15 at 3 31 12 PM](https://user-images.githubusercontent.com/16418650/96194781-f8e2e200-0eff-11eb-8075-07dcc08ad98b.png)

**Figure 2.**
![Screen Shot 2020-10-15 at 4 02 58 PM](https://user-images.githubusercontent.com/16418650/96194788-fa140f00-0eff-11eb-9f37-9fd136c16e2b.png)
