### PR TITLE
BREAKING: Add subheading to button bar

### DIFF
--- a/components/button-bar.vue
+++ b/components/button-bar.vue
@@ -55,6 +55,7 @@ export default {
 
 <style module lang="scss">
 	@import '../styles/variables';
+	@import '../styles/mixins';
 
 	.root {
 		display: flex;

--- a/components/button-bar.vue
+++ b/components/button-bar.vue
@@ -4,17 +4,15 @@
 			v-for="(buttonLabel, index) in buttonLabels"
 			:class="[
 				$style.button,
-				{ [$style.isActive]: buttonLabel === selectedLabel || buttonLabel['heading'] === selectedLabel }
+				{ [$style.isActive]: buttonLabel.heading === selectedLabel }
 			]"
-			@click="$emit('change', isObject(buttonLabel) ? buttonLabel['heading'] : buttonLabel)"
+			@click="$emit('change', buttonLabel.heading)"
 			:key="index"
 		>
-			<div v-if="isObject(buttonLabel)">
-				{{ buttonLabel['heading'] }}
-				<div :class="$style.subheading">{{ buttonLabel['subheading'] }}</div>
+			<div>
+				<div>{{ buttonLabel.heading }}</div>
+				<div :class="$style.subheading">{{ buttonLabel.subheading }}</div>
 			</div>
-
-			<div v-else>{{ buttonLabel }}</div>
 		</div>
 	</div>
 </template>

--- a/components/button-bar.vue
+++ b/components/button-bar.vue
@@ -1,9 +1,12 @@
 <template>
 	<div :class="$style.root" v-if="convertedButtonLabels">
 		<div
-			v-for="(buttonLabel, index) in buttonLabels"
-			:class="[$style.button, { [$style.isActive]: buttonLabel === selectedLabel }]"
-			@click="$emit('change', buttonLabel)"
+			v-for="(buttonLabel, index) in convertedButtonLabels"
+			:class="[
+				$style.button,
+				{ [$style.isActive]: buttonLabel === selectedLabel || buttonLabel['heading'] === selectedLabel }
+			]"
+			@click="$emit('change', isObject(buttonLabel) ? buttonLabel['heading'] : buttonLabel)"
 			:key="index"
 		>
 			{{ buttonLabel }}

--- a/components/button-bar.vue
+++ b/components/button-bar.vue
@@ -35,15 +35,16 @@ export default {
 	@import '../styles/variables';
 	@import '../styles/mixins';
 
-	.root {
+	.root,
+	.button {
 		display: flex;
 	}
 
 	.button {
 		flex: 1;
+		justify-content: center;
+		align-items: center;
 		text-align: center;
-		display: grid;
-		place-items: center;
 		padding: $spacing-05;
 		border: $border-light;
 		border-right: 0;

--- a/components/button-bar.vue
+++ b/components/button-bar.vue
@@ -1,5 +1,5 @@
 <template>
-	<div :class="$style.root">
+	<div :class="$style.root" v-if="convertedButtonLabels">
 		<div
 			v-for="(buttonLabel, index) in buttonLabels"
 			:class="[$style.button, { [$style.isActive]: buttonLabel === selectedLabel }]"

--- a/components/button-bar.vue
+++ b/components/button-bar.vue
@@ -28,7 +28,7 @@ export default {
 			type: String,
 		},
 	},
-					};
+};
 </script>
 
 <style module lang="scss">

--- a/components/button-bar.vue
+++ b/components/button-bar.vue
@@ -28,27 +28,7 @@ export default {
 			type: String,
 		},
 	},
-	methods: {
-		isObject(object) {
-			return Object.prototype.toString.call(object) === '[object Object]';
-		},
-	},
-	computed: {
-		convertedButtonLabels() {
-			return this.buttonLabels.map(label => {
-				if (Array.isArray(label)) {
-					return {
-						heading: label[0],
-						subheading: label[1],
 					};
-				}
-
-				return label;
-			});
-		},
-	},
-};
-
 </script>
 
 <style module lang="scss">

--- a/components/button-bar.vue
+++ b/components/button-bar.vue
@@ -1,17 +1,17 @@
 <template>
 	<div :class="$style.root">
 		<div
-			v-for="(buttonLabel, index) in buttonLabels"
+			v-for="(button, index) in buttons"
 			:class="[
 				$style.button,
-				{ [$style.isActive]: buttonLabel.heading === selectedLabel }
+				{ [$style.isActive]: button === selected }
 			]"
-			@click="$emit('change', buttonLabel.heading)"
+			@click="$emit('change', button)"
 			:key="index"
 		>
 			<div>
-				<div>{{ buttonLabel.heading }}</div>
-				<div :class="$style.subheading">{{ buttonLabel.subheading }}</div>
+				<div>{{ button.heading }}</div>
+				<div :class="$style.subheading">{{ button.subheading }}</div>
 			</div>
 		</div>
 	</div>
@@ -20,12 +20,12 @@
 <script>
 export default {
 	props: {
-		buttonLabels: {
+		buttons: {
 			type: Array,
 			required: true,
 		},
-		selectedLabel: {
-			type: String,
+		selected: {
+			type: Object,
 		},
 	},
 };

--- a/components/button-bar.vue
+++ b/components/button-bar.vue
@@ -27,6 +27,21 @@ export default {
 			return Object.prototype.toString.call(object) === '[object Object]';
 		},
 	},
+	computed: {
+		convertedButtonLabels() {
+			return this.buttonLabels.map(label => {
+				if (Array.isArray(label)) {
+					return {
+						heading: label[0],
+						subheading: label[1],
+					};
+				}
+
+				return label;
+			});
+		},
+	},
+};
 };
 </script>
 

--- a/components/button-bar.vue
+++ b/components/button-bar.vue
@@ -22,6 +22,11 @@ export default {
 			type: String,
 		},
 	},
+	methods: {
+		isObject(object) {
+			return Object.prototype.toString.call(object) === '[object Object]';
+		},
+	},
 };
 </script>
 

--- a/components/button-bar.vue
+++ b/components/button-bar.vue
@@ -26,6 +26,7 @@ export default {
 		},
 		selected: {
 			type: Object,
+			required: true,
 		},
 	},
 };

--- a/components/button-bar.vue
+++ b/components/button-bar.vue
@@ -50,7 +50,7 @@ export default {
 		},
 	},
 };
-};
+
 </script>
 
 <style module lang="scss">

--- a/components/button-bar.vue
+++ b/components/button-bar.vue
@@ -9,7 +9,12 @@
 			@click="$emit('change', isObject(buttonLabel) ? buttonLabel['heading'] : buttonLabel)"
 			:key="index"
 		>
-			{{ buttonLabel }}
+			<div v-if="isObject(buttonLabel)" :class="$style.twoColLabel">
+				{{ buttonLabel['heading'] }}
+				<div :class="$style.sublabel">{{ buttonLabel['subheading'] }}</div>
+			</div>
+
+			<div v-else>{{ buttonLabel }}</div>
 		</div>
 	</div>
 </template>

--- a/components/button-bar.vue
+++ b/components/button-bar.vue
@@ -64,6 +64,8 @@ export default {
 	.button {
 		flex: 1;
 		text-align: center;
+		display: grid;
+		place-items: center;
 		padding: $spacing-05;
 		border: $border-light;
 		border-right: 0;

--- a/components/button-bar.vue
+++ b/components/button-bar.vue
@@ -9,9 +9,9 @@
 			@click="$emit('change', isObject(buttonLabel) ? buttonLabel['heading'] : buttonLabel)"
 			:key="index"
 		>
-			<div v-if="isObject(buttonLabel)" :class="$style.twoColLabel">
+			<div v-if="isObject(buttonLabel)">
 				{{ buttonLabel['heading'] }}
-				<div :class="$style.sublabel">{{ buttonLabel['subheading'] }}</div>
+				<div :class="$style.subheading">{{ buttonLabel['subheading'] }}</div>
 			</div>
 
 			<div v-else>{{ buttonLabel }}</div>
@@ -85,11 +85,7 @@ export default {
 		background-color: $beige;
 	}
 
-	.twoColLabel {
-		flex-flow: column;
-	}
-
-	.sublabel {
+	.subheading {
 		@include text-body-small();
 		@include text-subtle();
 	}

--- a/components/button-bar.vue
+++ b/components/button-bar.vue
@@ -1,7 +1,7 @@
 <template>
 	<div :class="$style.root">
 		<div
-			v-for="(buttonLabel, index) in convertedButtonLabels"
+			v-for="(buttonLabel, index) in buttonLabels"
 			:class="[
 				$style.button,
 				{ [$style.isActive]: buttonLabel === selectedLabel || buttonLabel['heading'] === selectedLabel }

--- a/components/button-bar.vue
+++ b/components/button-bar.vue
@@ -9,10 +9,8 @@
 			@click="$emit('change', button)"
 			:key="index"
 		>
-			<div>
-				<div>{{ button.heading }}</div>
-				<div :class="$style.subheading">{{ button.subheading }}</div>
-			</div>
+			<div>{{ button.heading }}</div>
+			<div :class="$style.subheading">{{ button.subheading }}</div>
 		</div>
 	</div>
 </template>
@@ -43,6 +41,7 @@ export default {
 
 	.button {
 		flex: 1;
+		flex-direction: column;
 		justify-content: center;
 		align-items: center;
 		text-align: center;

--- a/components/button-bar.vue
+++ b/components/button-bar.vue
@@ -83,4 +83,13 @@ export default {
 	.isActive {
 		background-color: $beige;
 	}
+
+	.twoColLabel {
+		flex-flow: column;
+	}
+
+	.sublabel {
+		@include text-body-small();
+		@include text-subtle();
+	}
 </style>

--- a/components/button-bar.vue
+++ b/components/button-bar.vue
@@ -1,5 +1,5 @@
 <template>
-	<div :class="$style.root" v-if="convertedButtonLabels">
+	<div :class="$style.root">
 		<div
 			v-for="(buttonLabel, index) in convertedButtonLabels"
 			:class="[

--- a/stories/components/basic/button-bar.js
+++ b/stories/components/basic/button-bar.js
@@ -8,17 +8,11 @@ export default {
 export function Overview() {
 	return {
 		components: { ButtonBar },
-		template: `
-			<button-bar
-				:button-labels="buttonLabels"
-				:selected-label="selectedLabel"
-				@change="onChange"
-			/>
-		`,
+		template: '<button-bar :buttons="buttons" :selected="selected" @change="onChange" />',
 		data() {
 			return {
-				selectedLabel: 'Pick Up',
-				buttonLabels: [
+				selected: null,
+				buttons: [
 					{ heading: 'Pick Up' },
 					{ heading: 'Delivery' },
 					{ heading: 'Shipping' },
@@ -27,7 +21,7 @@ export function Overview() {
 		},
 		methods: {
 			onChange(value) {
-				this.selectedLabel = value;
+				this.selected = value;
 			},
 		},
 	};
@@ -35,17 +29,11 @@ export function Overview() {
 export function SecondRow() {
 	return {
 		components: { ButtonBar },
-		template: `
-			<button-bar
-				:button-labels="buttonLabels"
-				:selected-label="selectedLabel"
-				@change="onChange"
-			/>
-		`,
+		template: '<button-bar :buttons="buttons" :selected="selected" @change="onChange" />',
 		data() {
 			return {
-				selectedLabel: 'Test 2',
-				buttonLabels: [
+				selected: null,
+				buttons: [
 					{ heading: 'Test 1', subheading: 'Test 1 Sub' },
 					{ heading: 'Test 2', subheading: 'Test 2 Sub' },
 					{ heading: 'Test 3', subheading: 'Test 3 Sub' },
@@ -55,7 +43,7 @@ export function SecondRow() {
 		},
 		methods: {
 			onChange(value) {
-				this.selectedLabel = value;
+				this.selected = value;
 			},
 		},
 	};

--- a/stories/components/basic/button-bar.js
+++ b/stories/components/basic/button-bar.js
@@ -27,3 +27,25 @@ export function Overview() {
 		},
 	};
 }
+export function DoubleColumnAsArray() {
+	return {
+		components: { ButtonBar },
+		template: `
+			<button-bar
+				:button-labels="['TestOne', ['TestTwo', 'TestTwoSubheading'], 'TestThree']"
+				:selected-label="selectedLabel"
+				@change="onChange"
+			/>
+		`,
+		data() {
+			return {
+				selectedLabel: 'TestTwo',
+			};
+		},
+		methods: {
+			onChange(value) {
+				this.selectedLabel = value;
+			},
+		},
+	};
+}

--- a/stories/components/basic/button-bar.js
+++ b/stories/components/basic/button-bar.js
@@ -19,6 +19,9 @@ export function Overview() {
 				],
 			};
 		},
+		created() {
+			this.selected = this.buttons[0];
+		},
 		methods: {
 			onChange(value) {
 				this.selected = value;
@@ -40,6 +43,9 @@ export function SecondRow() {
 					{ heading: 'Test 4' },
 				],
 			};
+		},
+		created() {
+			this.selected = this.buttons[0];
 		},
 		methods: {
 			onChange(value) {

--- a/stories/components/basic/button-bar.js
+++ b/stories/components/basic/button-bar.js
@@ -10,7 +10,7 @@ export function Overview() {
 		components: { ButtonBar },
 		template: `
 			<button-bar
-				:button-labels="['Pick Up', 'Delivery', 'Shipping']"
+				:button-labels="buttonLabels"
 				:selected-label="selectedLabel"
 				@change="onChange"
 			/>
@@ -18,6 +18,11 @@ export function Overview() {
 		data() {
 			return {
 				selectedLabel: 'Pick Up',
+				buttonLabels: [
+					{ heading: 'Pick Up' },
+					{ heading: 'Delivery' },
+					{ heading: 'Shipping' },
+				],
 			};
 		},
 		methods: {
@@ -32,14 +37,20 @@ export function SecondRowAsArray() {
 		components: { ButtonBar },
 		template: `
 			<button-bar
-				:button-labels="['TestOne', ['TestTwo', 'TestTwoSubheading'], 'TestThree']"
+				:button-labels="buttonLabels"
 				:selected-label="selectedLabel"
 				@change="onChange"
 			/>
 		`,
 		data() {
 			return {
-				selectedLabel: 'TestTwo',
+				selectedLabel: 'Test 2',
+				buttonLabels: [
+					{ heading: 'Test 1', subheading: 'Test 1 Sub' },
+					{ heading: 'Test 2', subheading: 'Test 2 Sub' },
+					{ heading: 'Test 3', subheading: 'Test 3 Sub' },
+					{ heading: 'Test 4' },
+				],
 			};
 		},
 		methods: {

--- a/stories/components/basic/button-bar.js
+++ b/stories/components/basic/button-bar.js
@@ -61,25 +61,3 @@ export function SecondRowAsArray() {
 	};
 }
 
-export function SecondRowAsObject() {
-	return {
-		components: { ButtonBar },
-		template: `
-			<button-bar
-				:button-labels="['TestOne', { heading: 'TestTwo', subheading: 'TestSubheading' }, 'TestThree']"
-				:selected-label="selectedLabel"
-				@change="onChange"
-			/>
-		`,
-		data() {
-			return {
-				selectedLabel: 'TestTwo',
-			};
-		},
-		methods: {
-			onChange(value) {
-				this.selectedLabel = value;
-			},
-		},
-	};
-}

--- a/stories/components/basic/button-bar.js
+++ b/stories/components/basic/button-bar.js
@@ -27,7 +27,7 @@ export function Overview() {
 		},
 	};
 }
-export function DoubleColumnAsArray() {
+export function SecondRowAsArray() {
 	return {
 		components: { ButtonBar },
 		template: `
@@ -50,7 +50,7 @@ export function DoubleColumnAsArray() {
 	};
 }
 
-export function DoubleColumnAsObject() {
+export function SecondRowAsObject() {
 	return {
 		components: { ButtonBar },
 		template: `

--- a/stories/components/basic/button-bar.js
+++ b/stories/components/basic/button-bar.js
@@ -49,3 +49,26 @@ export function DoubleColumnAsArray() {
 		},
 	};
 }
+
+export function DoubleColumnAsObject() {
+	return {
+		components: { ButtonBar },
+		template: `
+			<button-bar
+				:button-labels="['TestOne', { heading: 'TestTwo', subheading: 'TestSubheading' }, 'TestThree']"
+				:selected-label="selectedLabel"
+				@change="onChange"
+			/>
+		`,
+		data() {
+			return {
+				selectedLabel: 'TestTwo',
+			};
+		},
+		methods: {
+			onChange(value) {
+				this.selectedLabel = value;
+			},
+		},
+	};
+}

--- a/stories/components/basic/button-bar.js
+++ b/stories/components/basic/button-bar.js
@@ -32,7 +32,7 @@ export function Overview() {
 		},
 	};
 }
-export function SecondRowAsArray() {
+export function SecondRow() {
 	return {
 		components: { ButtonBar },
 		template: `


### PR DESCRIPTION
This PR modifies the `button-bar` component to accept an array of arrays, or preferably an array of objects, to render them as a two column button bar. As far as I can tell there are no breaking changes.

Acceptable inputs:

`['ItemOne', ['ItemTwo', 'ItemTwoSubheading'], 'ItemThree']` or `['ItemOne', {heading: 'ItemTwo', subheading: 'ItemTwoSubheading'}, 'ItemThree']`

https://app.clickup.com/t/gyx5hk